### PR TITLE
Adds logic to check for environment variables

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -18,6 +18,16 @@ Available Commands:
 EOF
 }
 
+if [[ -z "${HELM_HOME}" ]]; then
+  HELM_HOME="${HOME}/.helm"
+fi
+
+if [[ -z "${HELM_PATH_STARTER}" ]]; then
+  HELM_PATH_STARTER="${HELM_HOME}/starters"
+fi
+
+mkdir -p "${HELM_PATH_STARTER}"
+
 # Create the passthru array
 PASSTHRU=()
 while [[ $# -gt 0 ]]


### PR DESCRIPTION
Checks for HELM_PATH_STARTER variable and defaults it to ${HELM_HOME}/starters if not set. It also creates the directory if it does not exist.